### PR TITLE
Add preferences.

### DIFF
--- a/src/data/js/find-url.js
+++ b/src/data/js/find-url.js
@@ -9,8 +9,12 @@ function findUrl(node, data) {
     // use canonical URL if it exists, current URL otherwise.
     canonical = document.querySelector(sel);
     if (!(canonical && (url = canonical.href || canonical.content)))
-      url = document.location.href;
+      url = window.location.href;
 
-    // return url with leading and trailing whitespace removed.
-    self.postMessage(url.trim());
+    // Return found URL, fallback URL and hash to add-on for processing.
+    self.postMessage({
+      'url': url.trim(),
+      'winLoc': window.location.href,
+      'hash': window.location.hash
+    });
   }

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -2,6 +2,7 @@ const clipboard = require('sdk/clipboard'),
 cm = require('sdk/context-menu'),
 data = require('sdk/self').data,
 notifications = require('sdk/notifications'),
+prefs = require('sdk/simple-prefs').prefs,
 tabs = require('sdk/tabs'),
 ui = require('sdk/ui');
 
@@ -47,11 +48,26 @@ function notify(txt) {
 }
 
 /** Take posted URL and copy to clipboard. */
-function processUrl(url) {
-  if (url) {
-    clipboard.set(url);
-    notify('Copied URL to clipboard:\n' + url);
-  } else {
+function processUrl(data) {
+  if (!data.url) {
     notify('ZOMG, error finding URL.');
+    return;
+  }
+
+  var url = data.url;
+
+  // Add or remove hash according to setting.
+  var hasHash = (data.hash && url.match(data.hash + '$'));
+  if (prefs.includeHash && !hasHash) {
+    url += data.hash;
+  } else if (!prefs.includeHash && hasHash) {
+    url = url.slice(0, - data.hash.length);
+  }
+
+  clipboard.set(url);
+
+  if (prefs.notify === 'always' ||
+    (prefs.notify === 'diff' && url !== data.winLoc)) {
+    notify('Copied URL to clipboard:\n' + url);
   }
 }

--- a/src/package.json
+++ b/src/package.json
@@ -3,14 +3,37 @@
   "title": "Copy URL",
   "id": "jid0-ZAHxU5e9sjK6VVQ8uP9TqpnlWuk@jetpack",
   "description": "Copy the URL of the current page to the clipboard at the click of a button.",
-  "author": "Fred Wenzel <fwenzel@mozilla.com>",
-  "version": "1.3.1",
+  "author": "Fred Wenzel <code@wenzel.io>",
+  "version": "1.4.0",
   "icon": {
     "64": "data/img/copy-url-64.png",
     "48": "data/img/copy-url-48.png",
     "32": "data/img/copy-url-32.png"
   },
   "main": "lib/main.js",
+  "preferences": [{
+    "name": "notify",
+    "title": "Show notification?",
+    "description": "Errors are always shown",
+    "type": "menulist",
+    "value": "always",
+    "options": [{
+      "value": "always",
+      "label": "Always show notification"
+    }, {
+      "value": "diff",
+      "label": "Only if copied URL differs from current page URL"
+    }, {
+      "value": "never",
+      "label": "Never show notification"
+    }]
+  }, {
+    "name": "includeHash",
+    "title": "Include Location Hash?",
+    "description": "The `#content` in http://.../page#content",
+    "type": "bool",
+    "value": false
+  }],
   "permissions": {
     "multiprocess": true,
     "private-browsing": true


### PR DESCRIPTION
Enable disabling notifications if URL is as expected or altogether. Fix #13.
Include or omit location hash (default: exclude). Fix #12.
